### PR TITLE
build: fix failing CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       id: bin
       run: |
         Copy-Item .\dist\backend.exe $env:RUNNER_TEMP\backend.exe
-        echo "path=$env:RUNNER_TEMP\backend.exe" >> $env:GITHUB_OUTPUT
+        echo "path=$env:RUNNER_TEMP\backend-win64.exe" >> $env:GITHUB_OUTPUT
       shell: pwsh
 
     - name: Set version tag


### PR DESCRIPTION
Fix Failing CI issue caused by incorrect path to exe